### PR TITLE
[Setting] Vercel 배포를 위한 Github Action 세팅

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./deploy.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: "output"
+          destination-github-username: 2dowon
+          destination-repository-name: are-you-real-t-client
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./are-you-real-t-client/* ./output
+cp -R ./output ./are-you-real-t-client/


### PR DESCRIPTION
- Organization repo에서 vercel로 배포하기 위해서는 프로 계정이 필요함
- 따라서 Organization repo를 개인 repo로 fork하여 vercel 배포 진행
- sync를 맞추기 위한 github action을 추가하여 자동 배포