### PR TITLE
[Feat] 토론하기 질문 상세페이지 layout

### DIFF
--- a/app/community/[id]/_components/comment/CommentSection.tsx
+++ b/app/community/[id]/_components/comment/CommentSection.tsx
@@ -2,7 +2,7 @@ import Comment from "./Comment";
 import CommentInput from "./CommentInput.client";
 
 const CommentSection = () => (
-  <div className="px-[2rem] py-[5rem]">
+  <>
     <CommentInput />
 
     <div className="space-y-[1.6rem] mt-[3.2rem]">
@@ -23,7 +23,7 @@ const CommentSection = () => (
         comment="댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용댓글내용"
       />
     </div>
-  </div>
+  </>
 );
 
 export default CommentSection;

--- a/app/community/[id]/_components/questionDetail/QuestionDetailAnswerProgress.tsx
+++ b/app/community/[id]/_components/questionDetail/QuestionDetailAnswerProgress.tsx
@@ -1,0 +1,48 @@
+import { mbtiTypeMetaMap, TMbtiType } from "@/utils/constants/meta.const";
+
+const QuestionDetailAnswerProgress = ({
+  isSelected,
+  type,
+  tagPercentageMap,
+}: {
+  isSelected: boolean;
+  type: TMbtiType;
+  tagPercentageMap: { [tag: string]: number };
+}) => {
+  const { typeList } = mbtiTypeMetaMap[type];
+
+  return (
+    <div className="rounded-[0.8rem] relative h-[5.6rem] w-full bg-gray-10">
+      <div className="flex w-full justify-between px-[2rem] h-full items-center">
+        {typeList.map((type, index) => {
+          const percentage = tagPercentageMap[type];
+
+          return (
+            <div className="text-label z-10 flex items-center gap-x-[1rem]">
+              {index === 1 && <p>{percentage}%</p>}
+              {type}
+              {index === 0 && <p>{percentage}%</p>}
+            </div>
+          );
+        })}
+      </div>
+
+      {typeList.map((type, index) => {
+        const percentage = tagPercentageMap[type];
+        return (
+          <div
+            key={type}
+            className={`h-full rounded-[0.8rem] absolute top-0 ${
+              index === 0 ? "left-0" : "right-0"
+            } ${
+              percentage >= 50 ? (isSelected ? "bg-primary" : "bg-gray-25") : ""
+            }`}
+            style={{ width: `${percentage}%` }}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default QuestionDetailAnswerProgress;

--- a/app/community/[id]/_components/questionDetail/QuestionDetailAnswerSection.client.tsx
+++ b/app/community/[id]/_components/questionDetail/QuestionDetailAnswerSection.client.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { IAnswerDetail } from "@/hooks/api/question/useQuestion";
+import { TMbtiType } from "@/utils/constants/meta.const";
+import { useState } from "react";
+import QuestionDetailAnswerProgress from "./QuestionDetailAnswerProgress";
+
+const QuestionDetailAnswerSection = ({
+  type,
+  answerList,
+  answerCount,
+}: {
+  type: TMbtiType;
+  answerList: IAnswerDetail[];
+  answerCount: number;
+}) => {
+  const [selectedAnswerId, setSelectedAnswerId] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-[3rem]">
+      {answerList.map(({ id, content, tag, count }) => {
+        const numericAnswerId = Number(id);
+        const isSelected = selectedAnswerId === numericAnswerId;
+
+        return (
+          <div key={`question_detail_answer_${id}`} className="text-label">
+            <div className="text-label mb-[0.8rem] flex items-center gap-x-[0.5rem]">
+              <p>{content}</p>
+              {selectedAnswerId && <p>({count}명)</p>}
+            </div>
+
+            {selectedAnswerId ? (
+              <QuestionDetailAnswerProgress
+                isSelected={isSelected}
+                type={type}
+                tagPercentageMap={{ E: 70, I: 30 }}
+              />
+            ) : (
+              <Button
+                variant="gray"
+                size="md"
+                className="w-full text-label font-medium"
+                onClick={() => {
+                  setSelectedAnswerId(numericAnswerId);
+                }}
+              >
+                선택하기
+              </Button>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default QuestionDetailAnswerSection;

--- a/app/community/[id]/_components/questionDetail/QuestionDetailSection.tsx
+++ b/app/community/[id]/_components/questionDetail/QuestionDetailSection.tsx
@@ -1,0 +1,23 @@
+import { IQuestionDetail } from "@/hooks/api/question/useQuestion";
+import QuestionDetailAnswerSection from "./QuestionDetailAnswerSection.client";
+
+const QuestionDetailSection = ({ question }: { question: IQuestionDetail }) => {
+  const { content, answerList, answerCount, type } = question;
+  return (
+    <div>
+      <p className="text-title font-semibold mb-[2rem]">{content}</p>
+
+      <QuestionDetailAnswerSection
+        type={type}
+        answerList={answerList}
+        answerCount={answerCount}
+      />
+
+      <p className="text-label mt-[2rem]">
+        답변 참여자 {answerCount.toLocaleString()}명
+      </p>
+    </div>
+  );
+};
+
+export default QuestionDetailSection;

--- a/app/community/[id]/page.tsx
+++ b/app/community/[id]/page.tsx
@@ -3,8 +3,14 @@ import { getQuestion } from "@/hooks/api/question/useQuestion";
 import CommentSection from "./_components/comment/CommentSection";
 import QuestionDetailSection from "./_components/questionDetail/QuestionDetailSection";
 
-const CommunityPostPage = async () => {
-  const question = await getQuestion();
+interface ICommunityQuestionDetailPageProps {
+  params: { id: string };
+}
+
+const CommunityQuestionDetailPage = async ({
+  params: { id },
+}: ICommunityQuestionDetailPageProps) => {
+  const question = await getQuestion({ questionId: Number(id) });
 
   return (
     <div className="pb-[10rem] px-[2rem]">
@@ -24,4 +30,4 @@ const CommunityPostPage = async () => {
   );
 };
 
-export default CommunityPostPage;
+export default CommunityQuestionDetailPage;

--- a/app/community/[id]/page.tsx
+++ b/app/community/[id]/page.tsx
@@ -1,9 +1,25 @@
+import Caret from "@/components/icon/Caret";
+import { getQuestion } from "@/hooks/api/question/useQuestion";
 import CommentSection from "./_components/comment/CommentSection";
+import QuestionDetailSection from "./_components/questionDetail/QuestionDetailSection";
 
-const CommunityPostPage = () => {
+const CommunityPostPage = async () => {
+  const question = await getQuestion();
+
   return (
-    <div className="pb-[10rem]">
-      <CommentSection />
+    <div className="pb-[10rem] px-[2rem]">
+      <div className="flex items-center gap-x-[1rem] py-[2rem]">
+        <Caret />
+        <p className="text-label">다른 질문 보기</p>
+      </div>
+
+      <div className="pb-[1rem]">
+        <QuestionDetailSection question={question} />
+      </div>
+
+      <div className="border-t border-gray-25 py-[2rem]">
+        <CommentSection />
+      </div>
     </div>
   );
 };

--- a/app/community/_components/QuestionItem.tsx
+++ b/app/community/_components/QuestionItem.tsx
@@ -1,3 +1,7 @@
+import Comment from "@/components/icon/Comment";
+import Vote from "@/components/icon/Vote";
+import { IAnswer } from "@/hooks/api/questions/useQuestions";
+import { mbtiTypeMetaMap, TMbtiType } from "@/utils/constants/meta.const";
 import Link from "next/link";
 
 const QuestionItem = ({
@@ -9,35 +13,45 @@ const QuestionItem = ({
   commentCount,
 }: {
   postId: number;
-  type: string;
+  type: TMbtiType;
   questionTitle: string;
-  answerList: string[];
+  answerList: IAnswer[];
   answerCount: number;
   commentCount: number;
 }) => {
+  const { typeText } = mbtiTypeMetaMap[type];
+
   return (
     <Link href={`/community/${postId}`}>
       <div className="bg-gray-10 rounded-[1.6rem] p-[2.5rem]">
-        <p className="text-primary text-button mb-[0.8rem]">{type}</p>
+        <p className="text-primary text-label font-bold mb-[0.8rem]">
+          {typeText}
+        </p>
 
-        <p className="text-gray-100 text-title-question">{questionTitle}</p>
+        <p className="text-title-question">{questionTitle}</p>
 
         <div className="space-y-[1.2rem] my-[2.4rem]">
-          {answerList.map((answer, index) => {
+          {answerList.map(({ id, content }) => {
             return (
               <div
-                key={`answer_${index}`}
-                className="text-gray-100 bg-gray-18 p-[1.6rem] rounded-[0.8rem]"
+                key={`answer_${id}`}
+                className="bg-gray-18 p-[1.6rem] rounded-[0.8rem]"
               >
-                {answer}
+                <p className="break-all text-label line-clamp-1">{content}</p>
               </div>
             );
           })}
         </div>
 
-        <div className="flex items-center space-x-[1.6rem] text-gray-100">
-          <p>투표수 {answerCount}회</p>
-          <p>댓글 {commentCount}개</p>
+        <div className="flex items-center space-x-[1.6rem] text-[1.4rem] font-semibold tracking-[0.04%]">
+          <div className="flex items-center gap-x-[0.4rem]">
+            <Vote />
+            <p>투표수 {answerCount}회</p>
+          </div>
+          <div className="flex items-center gap-x-[0.4rem]">
+            <Comment />
+            <p>댓글 {commentCount}개</p>
+          </div>
         </div>
       </div>
     </Link>

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,48 +1,31 @@
+import { getQuestions } from "@/hooks/api/questions/useQuestions";
 import QuestionItem from "./_components/QuestionItem";
 
-const CommunityPage = () => {
+const CommunityPage = async () => {
+  const questionList = await getQuestions();
+
   return (
     <div>
-      <h1 className="text-white text-title-question mb-[1rem]">
+      <h1 className="text-white text-title-question mt-[3.2rem] mb-[2.4rem] mx-[2rem]">
         토론하러 가기
       </h1>
 
       <div className="mx-[2rem] flex flex-col gap-y-[2.4rem]">
-        <QuestionItem
-          postId={1}
-          type="S/N"
-          questionTitle="질문 내용"
-          answerList={["A", "B"]}
-          answerCount={1000}
-          commentCount={100}
-        />
-
-        <QuestionItem
-          postId={1}
-          type="S/N"
-          questionTitle="질문 내용"
-          answerList={["A", "B"]}
-          answerCount={1000}
-          commentCount={100}
-        />
-
-        <QuestionItem
-          postId={1}
-          type="S/N"
-          questionTitle="질문 내용"
-          answerList={["A", "B"]}
-          answerCount={1000}
-          commentCount={100}
-        />
-
-        <QuestionItem
-          postId={1}
-          type="S/N"
-          questionTitle="질문 내용"
-          answerList={["A", "B"]}
-          answerCount={1000}
-          commentCount={100}
-        />
+        {questionList.map(
+          ({ id, type, content, answerList, answerCount, commentCount }) => {
+            return (
+              <QuestionItem
+                key={`question_${id}`}
+                postId={Number(id)}
+                type={type}
+                questionTitle={content}
+                answerList={answerList}
+                answerCount={answerCount}
+                commentCount={commentCount}
+              />
+            );
+          }
+        )}
       </div>
     </div>
   );

--- a/components/icon/Caret.tsx
+++ b/components/icon/Caret.tsx
@@ -13,9 +13,9 @@ const Caret = ({ color = "white", className }: IconProps) => {
       <path
         d="M8.5 15L1.5 8L8.5 1"
         stroke={color}
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/components/icon/Comment.tsx
+++ b/components/icon/Comment.tsx
@@ -1,0 +1,23 @@
+import { IconProps } from "./icon.types";
+
+const Comment = ({ color = "#FF53AB", className }: IconProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      className={className}
+    >
+      <path
+        d="M11.4863 7.66667C11.4863 8.28333 10.9867 8.775 10.3789 8.775H3.70948L1.48633 11V2.10833C1.48633 1.49167 1.98591 1 2.59374 1H10.3623C10.9784 1 11.4697 1.5 11.4697 2.10833V7.66667H11.4863Z"
+        stroke={color}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default Comment;

--- a/components/icon/Vote.tsx
+++ b/components/icon/Vote.tsx
@@ -1,0 +1,29 @@
+import { IconProps } from "./icon.types";
+
+const Vote = ({ color = "#FF53AB", className }: IconProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="15"
+      height="14"
+      viewBox="0 0 15 14"
+      fill="none"
+      className={className}
+    >
+      <path
+        d="M5.48633 6.5L7.33248 8L13.4863 3"
+        stroke={color}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12.4863 7V10.8889C12.4863 11.5 11.9863 12 11.3752 12H3.59744C2.98633 12 2.48633 11.5 2.48633 10.8889V3.11111C2.48633 2.5 2.98633 2 3.59744 2H9.70855"
+        stroke={color}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default Vote;

--- a/hooks/api/question/useQuestion.ts
+++ b/hooks/api/question/useQuestion.ts
@@ -9,7 +9,11 @@ export interface IAnswerDetail extends IAnswer {
   count: number;
 }
 
-export const getQuestion = async () => {
+interface IQuestionParams {
+  questionId: number;
+}
+
+export const getQuestion = async (params: IQuestionParams) => {
   // const response = await areYouRealTServiceServerFetchInstance<IQuestion>(
   //   "/questions",
   //   {
@@ -18,6 +22,8 @@ export const getQuestion = async () => {
   // );
 
   // return response;
+
+  console.log("##  getQuestion params", params);
 
   return {
     id: "1",

--- a/hooks/api/question/useQuestion.ts
+++ b/hooks/api/question/useQuestion.ts
@@ -1,0 +1,43 @@
+import { IAnswer } from "@/hooks/api/questions/useQuestions";
+import { IQuestion } from "../questions/useQuestions";
+
+export interface IQuestionDetail extends Omit<IQuestion, "answerList"> {
+  answerList: IAnswerDetail[];
+}
+
+export interface IAnswerDetail extends IAnswer {
+  count: number;
+}
+
+export const getQuestion = async () => {
+  // const response = await areYouRealTServiceServerFetchInstance<IQuestion>(
+  //   "/questions",
+  //   {
+  //     method: "GET",
+  //   }
+  // );
+
+  // return response;
+
+  return {
+    id: "1",
+    type: "energy",
+    answerCount: 1000,
+    commentCount: 100,
+    content: "평생 취미를 하나만 가질 수 있다면?",
+    answerList: [
+      {
+        id: "1",
+        content: "평생 망원경으로 우주 관측하고 칼세이건 되기",
+        tag: "N",
+        count: 300,
+      },
+      {
+        id: "2",
+        content: "평생 현미경으로 미생물 관찰하고 파스퇴르 되기",
+        tag: "S",
+        count: 700,
+      },
+    ],
+  } as IQuestionDetail;
+};

--- a/hooks/api/questions/useQuestions.ts
+++ b/hooks/api/questions/useQuestions.ts
@@ -1,10 +1,15 @@
+import { TMbtiType } from "@/utils/constants/meta.const";
+
 export interface IQuestion {
   id: string;
   content: string;
   answerList: IAnswer[];
+  type: TMbtiType;
+  answerCount: number;
+  commentCount: number;
 }
 
-interface IAnswer {
+export interface IAnswer {
   id: string;
   content: string;
   tag: string;
@@ -23,6 +28,9 @@ export const getQuestions = async () => {
   return [
     {
       id: "1",
+      type: "energy",
+      answerCount: 1000,
+      commentCount: 100,
       content: "평생 취미를 하나만 가질 수 있다면?",
       answerList: [
         {
@@ -39,6 +47,9 @@ export const getQuestions = async () => {
     },
     {
       id: "2",
+      type: "information",
+      answerCount: 2000,
+      commentCount: 150,
       content: "인생이 막막할때",
       answerList: [
         {

--- a/utils/constants/meta.const.ts
+++ b/utils/constants/meta.const.ts
@@ -1,0 +1,10 @@
+export type TMbtiType = "energy" | "information" | "decision" | "lifeStyle";
+
+export const mbtiTypeMetaMap: {
+  [key in TMbtiType]: { typeList: string[]; typeText: string };
+} = {
+  energy: { typeList: ["I", "E"], typeText: "I/E" },
+  information: { typeList: ["S", "N"], typeText: "S/N" },
+  decision: { typeList: ["T", "F"], typeText: "T/F" },
+  lifeStyle: { typeList: ["J", "P"], typeText: "J/P" },
+};


### PR DESCRIPTION
<!-- @format -->

## 주제 : 토론하기 질문 상세페이지 layout

### 시안
https://www.figma.com/design/EdOeCHRnQBC6ipA1cxOjiu/%5B%EB%84%88%EC%A7%84%EC%A7%9CT%EC%95%BC%3F%5D-UXUI%EB%94%94%EC%9E%90%EC%9D%B8?node-id=2472-3401&t=zdN2Ld61nsZEs1Ld-4

### 상세

- 확인용 url : http://localhost:3000/community/1

### 개발
- 토론하기 질문 상세페이지 layout 구현


### 미비 사항
- style 수정
- api 연동

